### PR TITLE
fix: oldIDL and oldHTTP reference error

### DIFF
--- a/whistle.easy-mock/initial.js
+++ b/whistle.easy-mock/initial.js
@@ -10,8 +10,8 @@ function updateOldVersion(storage) {
       title: 'Default',
       id: 'default',
       rules: {
-        idl: oldIDL ?? [],
-        http: oldHTTP ?? [],
+        idl: typeof oldIDL === 'undefined' ? [] : oldIDL,
+        http: typeof oldHTTP === 'undefined' ? [] : oldHTTP,
       },
     };
     collections.unshift(defaultCollection);


### PR DESCRIPTION
<img width="1029" alt="Screen Shot 2022-03-14 at 12 01 55 PM" src="https://user-images.githubusercontent.com/12092809/158269800-fbc782c7-8c02-4643-bcf8-658b45be7c46.png">

These two variables got undefined error on my setup. Changed to bypass the referenceError